### PR TITLE
Run Vale on modified files

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -17,7 +17,14 @@ const {GITHUB_TOKEN, GITHUB_WORKSPACE} = process.env;
 export async function run(actionInput: input.Input): Promise<void> {
   try {
     const startedAt = new Date().toISOString();
-    const alertResp = await execa('vale', actionInput.args);
+
+    // (FORK) This is a hack to accommodate files modified before running Vale.
+    // Note this only works if the file's line numbers are not changed by the modifying function.
+    const modifiedArgs = actionInput.args.map(arg => arg.replace('.md', '.TEMP.md'));
+
+    const modifiedAlertResp = await execa('vale', modifiedArgs);
+    const alertResp = modifiedAlertResp.replaceAll('.TEMP.md', '.md');
+    // (ENDFORK)
 
     let runner = new CheckRunner(actionInput.files);
 


### PR DESCRIPTION
## Background

I can run the Vale CLI on stdin, like this:
```
cat content/foo.md | vale --ext=.md
```
This allows me to do a simple regex replacement before running Vale:
```
perl -p -e 's/{%.*?%}//g' content/foo.md | vale --ext=.md
```
☝️ It's useful to do this before running Vale rather than using Vale's build-in `TokenIgnores`, as the latter is [nontrivial](https://github.com/errata-ai/vale/issues/333#issuecomment-784546910).

Without the replacement, Vale doesn't work for me because my files aren't [CommonMark-compliant](https://github.com/errata-ai/vale/issues/387#issuecomment-990191932).

With the replacement, I get useful Vale output.

## This change

The challenge now is getting this hack to work with the Vale action, which doesn't support the stdin approach.

I plan to test by creating a custom workflow that uses this forked action.